### PR TITLE
Pi 2 not Pi II

### DIFF
--- a/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -193,7 +193,7 @@
     <value>Hi there, welcome to the Windows IoT Core Insider Preview</value>
   </data>
   <data name="Rpi2Name" xml:space="preserve">
-    <value>Raspberry Pi II</value>
+    <value>Raspberry Pi 2</value>
   </data>
   <data name="SkipStep.Text" xml:space="preserve">
     <value>Skip this step</value>


### PR DESCRIPTION
Official name is "Raspberry Pi 2"
https://www.raspberrypi.org/products/raspberry-pi-2-model-b/

Although Pi II sounds royal, i give you that .. Hmm maybe they should have gone for that one instead.