### PR TITLE
fixed comvert data from MCP3002

### DIFF
--- a/TempSensor/CS/MainPage.xaml.cs
+++ b/TempSensor/CS/MainPage.xaml.cs
@@ -81,9 +81,9 @@ namespace TempSensor
              */
 
             /*Uncomment if you are using mcp3002*/
-            int result = data[1] & 0x03;
+            int result = data[0] & 0x03;
             result <<= 8;
-            result += data[2];
+            result += data[1];
             return result;
         }
 


### PR DESCRIPTION
Recived data using satart from 6bit when using MCP3002 (10 bit A/D Converter).
- See also: MCP3002's data seat : https://buchizo.files.wordpress.com/2015/08/image15.png
