### PR TITLE
Making string comparison for boardname more robust

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/DeviceTypeInformation.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/DeviceTypeInformation.cs
@@ -15,19 +15,17 @@ namespace IoTCoreDefaultApp.Utils
                 if (_type == DeviceTypes.Unknown)
                 {
                     var deviceInfo = new EasClientDeviceInformation();
-                    switch (deviceInfo.SystemProductName)
+                    if (deviceInfo.SystemProductName.IndexOf("MinnowBoard", StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        case "Raspberry Pi 2 Model B":
-                            _type = DeviceTypes.RPI2;
-                            break;
-
-                        case "MinnowBoard MAX B3 PLATFORM":
-                            _type = DeviceTypes.MBM;
-                            break;
-
-                        default:
-                            _type = DeviceTypes.GenericBoard;
-                            break;
+                        _type = DeviceTypes.MBM; 
+                    }
+                    else if (deviceInfo.SystemProductName.IndexOf("Raspberry", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        _type = DeviceTypes.RPI2;
+                    }
+                    else
+                    {
+                        _type = DeviceTypes.GenericBoard;
                     }
                 }
                 return _type;


### PR DESCRIPTION
The latest firmware changed the strings that the API returns for MinnowBoard. I am changing the compare code to just search MinnowBoard/Raspberry in the product name. That should be good enough to detect MBM/Rpi2. 
