### PR TITLE
Resolved a bug where the C++ version of SerialSample would not read

### DIFF
--- a/SerialSample/CPP/MainPage.xaml.cpp
+++ b/SerialSample/CPP/MainPage.xaml.cpp
@@ -163,16 +163,17 @@ Concurrency::task<void> MainPage::ReadAsync(Concurrency::cancellation_token canc
         {
             rcvdText->Text = _dataReaderObject->ReadString(bytesRead);
             status->Text = "bytes read successfully!";
-
-            /*
-            Dynamically generate repeating tasks via "recursive" task creation - "recursively" call Listen() at the end of the continuation chain.
-            The "recursive" call is not true recursion. It will not accumulate stack since every recursive is made in a new task.
-            */
-
-            // start listening again after done with this chunk of incoming data
-            Listen();
         }
-    });
+
+
+        /*
+        Dynamically generate repeating tasks via "recursive" task creation - "recursively" call Listen() at the end of the continuation chain.
+        The "recursive" call is not true recursion. It will not accumulate stack since every recursive is made in a new task.
+        */
+
+        // start listening again after done with this chunk of incoming data
+        Listen();
+    } );
 }
 
 /// <summary>

--- a/SerialSample/CS/MainPage.xaml.cs
+++ b/SerialSample/CS/MainPage.xaml.cs
@@ -97,6 +97,7 @@ namespace SerialSample
                 serialPort.Parity = SerialParity.None;
                 serialPort.StopBits = SerialStopBitCount.One;
                 serialPort.DataBits = 8;
+                serialPort.Handshake = SerialHandshake.None;
 
                 // Display configured settings
                 status.Text = "Serial port configured successfully: ";


### PR DESCRIPTION
if a timeout occurs, no new Listen() call was being made. Listen() is now "recursively" (but not really) called regardless of success or failure of existing read to actually read any data
