### PR TITLE
WebCamSample: Add Cleanup() and fix 'ACCESS DENIED' bug

### DIFF
--- a/WebCamSample/CS/MainPage.xaml
+++ b/WebCamSample/CS/MainPage.xaml
@@ -46,6 +46,7 @@
         <StackPanel Grid.Row="1" x:Name="ContentRoot" HorizontalAlignment="Center" VerticalAlignment="Center" Orientation="Horizontal" Margin="12,0,0,0">
             <Button x:Name="video_init" Content="Initialize Audio/Video" Click="initVideo_Click" HorizontalAlignment="Left" Margin="0,0,30,20" Width="180"/>
             <Button x:Name="audio_init" Content="Initialize Audio Only" Click="initAudioOnly_Click" Margin="0,0,30,20" Width="120"/>
+            <Button x:Name="cleanup" Content="Close Camera" Click="cleanup_Click" Margin="0,0,30,20" Width="120"/>
         </StackPanel>
 
         <StackPanel Grid.Row="2" x:Name="ContentRootActions" HorizontalAlignment="Center" VerticalAlignment="Center" Orientation="Horizontal" Margin="12,0,12,0">


### PR DESCRIPTION
#1 Add Cleanup()
- 'Close Camera' button added to XAML UI
- When clicked, stops camera activities and disposes mediaCapture Object
- Cleanup() is also called when exceptions occur
#2 Fix 'ACCESS DENIED' bug
- This exception is thrown when there is a race condition between
  recording actions and playback actions. Happens only start/stop record
  is initiated when playback is still in progress.
- The fix provided is to handle this exception and stopping playback
  thus making sure that the video recording is accurate.
- Future recordings and playback will continue to work
