### PR TITLE
Deleting WinSDK.extcomp

### DIFF
--- a/WinSDK.extcomp
+++ b/WinSDK.extcomp
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <ExternalComponent Include="th2_release">
-      <Project>$/Xbox/XES/SDKs/Win10</Project>
-      <Version>10586</Version>
-    </ExternalComponent>
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
This is no longer required. We have a separate controller now with TH2 + VS Update 1. 
