### PR TITLE
Fix for parsing LSF Transition state parameters

### DIFF
--- a/AllJoyn/Platform/BridgeRT/ILSFHandler.h
+++ b/AllJoyn/Platform/BridgeRT/ILSFHandler.h
@@ -24,11 +24,11 @@ namespace BridgeRT
     public ref struct State sealed
     {
     public:
-        property bool IsOn;
-        property uint32 Brightness;
-        property uint32 Hue;
-        property uint32 Saturation;
-        property uint32 ColorTemp;
+        property Platform::IBox<bool>^ IsOn;
+		property Platform::IBox<uint32>^ Brightness;
+		property Platform::IBox<uint32>^ Hue;
+		property Platform::IBox<uint32>^ Saturation;
+		property Platform::IBox<uint32>^ ColorTemp;
     };
 
     // *********************************************************************************************************************************************************

--- a/AllJoyn/Platform/BridgeRT/LampState.cpp
+++ b/AllJoyn/Platform/BridgeRT/LampState.cpp
@@ -720,19 +720,19 @@ LampState::setStateParameter(_In_ alljoyn_msgarg msgArg, _Out_ State^ newState)
             }
             else
             {
-                if (strcmp(key, "Brightness") == 0)
+                if (strcmp(PROPERTY_BRIGHTNESS_STR, key)==0)
                 {
                     newState->Brightness = val;
                 }
-                else if (strcmp(key, "Hue") == 0)
+                else if (strcmp(PROPERTY_HUE_STR, key)==0)
                 {
                     newState->Hue = val;
                 }
-                else if (strcmp(key, "Saturation") == 0)
+                else if (strcmp(PROPERTY_SATURATION_STR, key)==0)
                 {
                     newState->Saturation = val;
-				}
-                else if (strcmp(key, "ColorTemp") == 0)
+                }
+                else if (strcmp(PROPERTY_COLOR_TEMP_STR, key) == 0)
                 {
                     newState->ColorTemp = val;
                 }

--- a/AllJoyn/Platform/BridgeRT/LampState.cpp
+++ b/AllJoyn/Platform/BridgeRT/LampState.cpp
@@ -720,19 +720,19 @@ LampState::setStateParameter(_In_ alljoyn_msgarg msgArg, _Out_ State^ newState)
             }
             else
             {
-                if (strcmp(PROPERTY_BRIGHTNESS_STR, key)==0)
+                if (strcmp(key, "Brightness") == 0)
                 {
                     newState->Brightness = val;
                 }
-                else if (strcmp(PROPERTY_HUE_STR, key)==0)
+                else if (strcmp(key, "Hue") == 0)
                 {
                     newState->Hue = val;
                 }
-                else if (strcmp(PROPERTY_SATURATION_STR, key)==0)
+                else if (strcmp(key, "Saturation") == 0)
                 {
                     newState->Saturation = val;
-                }
-                else if (strcmp(PROPERTY_COLOR_TEMP_STR, key) == 0)
+				}
+                else if (strcmp(key, "ColorTemp") == 0)
                 {
                     newState->ColorTemp = val;
                 }


### PR DESCRIPTION
- Makes State parameters optional by making them nullable
- Uses the key names rather than the parameter order to parse the provided state (order isn't specific nor are all parameters necessarily there)

@zhuridartem 
