### PR TITLE
Added a screensaver option to the default app

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/App.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/App.xaml.cs
@@ -121,6 +121,8 @@ namespace IoTCoreDefaultApp
             }
             // Ensure the current window is active
             Window.Current.Activate();
+
+            Screensaver.InitializeScreensaver();
         }
 
         protected override void OnActivated(IActivatedEventArgs args)

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
@@ -132,6 +132,9 @@
     <Compile Include="Views\OOBEWelcome.xaml.cs">
       <DependentUpon>OOBEWelcome.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\Screensaver.xaml.cs">
+      <DependentUpon>Screensaver.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Settings.xaml.cs">
       <DependentUpon>Settings.xaml</DependentUpon>
     </Compile>
@@ -216,6 +219,10 @@
     <Page Include="Views\OOBEWelcome.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ScreenSaver.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\Settings.xaml">
       <SubType>Designer</SubType>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -697,4 +697,8 @@
 {1}</value>
     <comment>Format for message displayed when an inbounbd pairing request is received</comment>
   </data>
+  <data name="EnableScreensaverText" xml:space="preserve">
+    <value>Screensaver</value>
+    <comment>Toggle switch for enabling the screensaver</comment>
+  </data>
 </root>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/Constants.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/Constants.cs
@@ -6,6 +6,7 @@ namespace IoTCoreDefaultApp
     {
         public static string HasDoneOOBEKey = "DefaultAppHasDoneOOBE";
         public static string HasDoneOOBEValue = "YES";
+        public static string EnableScreensaverKey = "DefaultAppEnableScreensaver";
         public const string GUID_DEVINTERFACE_USB_DEVICE = "A5DCBF10-6530-11D2-901F-00C04FB951ED";
         public static string[] TutorialDocNames = {
             "GetStarted",

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Screensaver.xaml
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Screensaver.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+    x:Class="IoTCoreDefaultApp.Screensaver"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:IoTCoreDefaultApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="480"
+    d:DesignWidth="800"
+	HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+
+	<Grid Background="Black">
+
+		<Image HorizontalAlignment="Left" VerticalAlignment="Top"
+			   Width="200" x:Name="image" Stretch="Uniform" />
+		
+    </Grid>
+</UserControl>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Screensaver.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Screensaver.xaml.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Windows.Storage;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace IoTCoreDefaultApp
+{
+    // The screensaver class triggers automatically after a certain amount of inactivity
+    // from keyboard or pointer events.
+    // Note: You should only use this screen saver if your device has a pointer or keyboard,
+    // or you won't be able to see the app after the screensaver starts.
+    //
+    // To re-use this screensaver, simply include this class and add the following line
+    // to the end of App.OnLaunched:
+    // Screensaver.InitializeScreensaver();
+    public sealed partial class Screensaver : UserControl
+    {
+        private static DispatcherTimer timeoutTimer;
+        private static Popup screensaverContainer;
+
+        /// <summary>
+        /// Initializes the screensaver
+        /// </summary>
+        public static void InitializeScreensaver()
+        {
+            screensaverContainer = new Popup()
+            {
+                Child = new Screensaver(),
+                Margin = new Thickness(0),
+                IsOpen = false
+            };
+            //Set screen saver to activate after 1 minute
+            timeoutTimer = new DispatcherTimer() { Interval = TimeSpan.FromMinutes(1) };
+            timeoutTimer.Tick += TimeoutTimer_Tick;
+            Window.Current.Content.AddHandler(UIElement.KeyDownEvent, new KeyEventHandler(App_KeyDown), true);
+            Window.Current.Content.AddHandler(UIElement.PointerMovedEvent, new PointerEventHandler(App_PointerEvent), true);
+            Window.Current.Content.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(App_PointerEvent), true);
+            Window.Current.Content.AddHandler(UIElement.PointerReleasedEvent, new PointerEventHandler(App_PointerEvent), true);
+            Window.Current.Content.AddHandler(UIElement.PointerEnteredEvent, new PointerEventHandler(App_PointerEvent), true);
+            if (IsScreensaverEnabled)
+            {
+                timeoutTimer.Start();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the screen saver should listen for inactivity and 
+        /// show after a little while. The default is <c>false</c>.
+        /// </summary>
+        public static bool IsScreensaverEnabled
+        {
+            get
+            {
+                if (ApplicationData.Current.LocalSettings.Values.ContainsKey(Constants.EnableScreensaverKey))
+                {
+                    return (bool)ApplicationData.Current.LocalSettings.Values[Constants.EnableScreensaverKey];
+                }
+                return false;
+            }
+            set
+            {
+                ApplicationData.Current.LocalSettings.Values[Constants.EnableScreensaverKey] = value;
+                if (timeoutTimer != null)
+                {
+                    if (value)
+                    {
+                        timeoutTimer.Start();
+                    }
+                    else
+                    {
+                        timeoutTimer.Stop();
+                    }
+                }
+            }
+        }
+
+        // Triggered when there hasn't been any key or pointer events in a while
+        private static void TimeoutTimer_Tick(object sender, object e)
+        {
+            ShowScreensaver();
+        }
+
+        private static void ShowScreensaver()
+        { 
+            timeoutTimer.Stop();
+            var bounds = Windows.UI.Core.CoreWindow.GetForCurrentThread().Bounds;
+            var view = (Screensaver)screensaverContainer.Child;
+            view.Width = bounds.Width;
+            view.Height = bounds.Height;
+            view.image.Width = view.Width / 5; //Make screensaver image 1/5 the width of the screen
+            screensaverContainer.IsOpen = true;
+        }
+
+        private static void App_KeyDown(object sender, KeyRoutedEventArgs args)
+        {
+            ResetScreensaverTimeout();
+        }
+
+        private static void App_PointerEvent(object sender, PointerRoutedEventArgs e)
+        {
+            ResetScreensaverTimeout();
+        }
+
+        // Resets the timer and starts over.
+        private static void ResetScreensaverTimeout()
+        {
+            timeoutTimer.Stop();
+            timeoutTimer.Start();
+            screensaverContainer.IsOpen = false;
+        }
+
+        private DispatcherTimer moveTimer;
+        private Random randomizer = new Random();
+
+        private Screensaver()
+        {
+            this.InitializeComponent();
+            moveTimer = new DispatcherTimer() { Interval = TimeSpan.FromSeconds(10) };
+            moveTimer.Tick += MoveTimer_Tick;
+            this.Loaded += ScreenSaver_Loaded;
+            this.Unloaded += ScreenSaver_Unloaded;
+            image.Source = new BitmapImage(DeviceInfoPresenter.GetBoardImageUri());
+        }
+
+        protected override void OnPointerMoved(PointerRoutedEventArgs e)
+        {
+            base.OnPointerMoved(e);
+            ResetScreensaverTimeout();
+        }
+
+        private void MoveTimer_Tick(object sender, object e)
+        {
+            var left = randomizer.NextDouble() * (this.ActualWidth - image.ActualWidth);
+            var top = randomizer.NextDouble() * (this.ActualHeight - image.ActualHeight);
+            image.Margin = new Thickness(left, top, 0, 0);
+        }
+
+        private void ScreenSaver_Unloaded(object sender, RoutedEventArgs e)
+        {
+            moveTimer.Stop();
+        }
+
+        private void ScreenSaver_Loaded(object sender, RoutedEventArgs e)
+        {
+            moveTimer.Start();
+            MoveTimer_Tick(moveTimer, null);
+        }
+    }
+}

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml
@@ -223,12 +223,18 @@
                     <RowDefinition Height="80"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="117*"/>
+					<RowDefinition Height="Auto"/>
+					<RowDefinition Height="117*"/>
                     <RowDefinition Height="172*"/>
                 </Grid.RowDefinitions>
-                <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding [LanguageTitleText]}" Style="{StaticResource SubtitleTextBlockStyle}" FontWeight="Normal" />
-				<ListBox Grid.Column="1" Grid.Row="2" HorizontalAlignment="Left" x:Name="LanguageListBox" FontSize="16" Margin="0,10,0,0" Width="446" SelectionChanged="LanguageListBox_SelectionChanged" />
-            </Grid>
+				<ToggleSwitch Grid.Column="1" Grid.Row="1" Style="{StaticResource IoTCoreDefaultAppToggleStyle}" Toggled="Screensaver_Toggled" x:Name="screensaverToggleSwitch" >
+					<ToggleSwitch.Header>
+						<TextBlock Text="{Binding [EnableScreensaverText]}" Style="{StaticResource SubtitleTextBlockStyle}" FontWeight="Normal" />
+					</ToggleSwitch.Header>
+				</ToggleSwitch>
+				<TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding [LanguageTitleText]}" Style="{StaticResource SubtitleTextBlockStyle}" FontWeight="Normal" />
+				<ListBox Grid.Column="1" Grid.Row="3" HorizontalAlignment="Left" x:Name="LanguageListBox" FontSize="16" Margin="0,10,0,0" Width="446" SelectionChanged="LanguageListBox_SelectionChanged" />
+			</Grid>
         </ScrollViewer>
 
         <ScrollViewer  x:Name="NetworkGrid" Grid.Column="2" Grid.Row="1" Visibility="Collapsed">

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
@@ -66,6 +66,7 @@ namespace IoTCoreDefaultApp
             this.Loaded += (sender, e) =>
             {
                 SetupLanguages();
+                screensaverToggleSwitch.IsOn = Screensaver.IsScreensaverEnabled;
             };
         }
 
@@ -950,6 +951,12 @@ namespace IoTCoreDefaultApp
             {
                 StopWatchingAndDisplayConfirmationMessage();
             }
+        }
+
+        private void Screensaver_Toggled(object sender, RoutedEventArgs e)
+        {
+            var screensaverToggleSwitch = sender as ToggleSwitch;
+            Screensaver.IsScreensaverEnabled = screensaverToggleSwitch.IsOn;
         }
     }
 }


### PR DESCRIPTION
This adds the screen saver option mentioned in https://github.com/ms-iot/samples/issues/117

The image for the screen saver uses the image returned from `DeviceInfoPresenter.GetBoardImageUri()`.
It is off by default but can be turned on in settings:
![image](https://cloud.githubusercontent.com/assets/1378165/12284898/05b21e70-b969-11e5-8c29-2536409f8645.png)

Preview of the screensaver (moves every 10 seconds):
![untitled](https://cloud.githubusercontent.com/assets/1378165/12284942/b3b2ef7c-b969-11e5-974d-2112d2cb7ea8.gif)

I built it so it's fairly easy for other people to copy and use in their own projects.

Let me know if you want any changes.

@stephenhuang
