### PR TITLE
Added missing reference to .NET Core for Background Task Project Templates

### DIFF
--- a/IotTemplates/WindowsIotCoreTemplates/ProjectTemplates/BackgroundServiceCsharp/project.json
+++ b/IotTemplates/WindowsIotCoreTemplates/ProjectTemplates/BackgroundServiceCsharp/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+		"Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
   },
 
   "frameworks": {

--- a/IotTemplates/WindowsIotCoreTemplates/ProjectTemplates/BackgroundServiceVB/project.json
+++ b/IotTemplates/WindowsIotCoreTemplates/ProjectTemplates/BackgroundServiceVB/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+		"Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
The background service template are missing a reference to .NET Core, causing compilation errors.

This addresses issue #199
