### PR TITLE
UpdateDateTime uses a native method

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Presenters\NetworkPresenter.cs" />
     <Compile Include="Utils\DeviceTypeInformation.cs" />
     <Compile Include="Utils\Constants.cs" />
+    <Compile Include="Utils\NativeTimeMethods.cs" />
     <Compile Include="Utils\NavigationUtils.cs" />
     <Compile Include="Utils\WifiGlyphConverter.cs" />
     <Compile Include="Views\MainPage.xaml.cs">

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/NativeTimeMethods.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/NativeTimeMethods.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace IoTCoreDefaultApp.Utils
+{
+    internal static class NativeTimeMethods
+    {
+        [DllImport("api-ms-win-core-sysinfo-l1-2-1.dll")]
+        internal static extern void GetLocalTime(out SYSTEMTIME lpLocalTime);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SYSTEMTIME
+    {
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Year;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Month;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short DayOfWeek;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Day;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Hour;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Minute;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Second;
+
+
+        [MarshalAs(UnmanagedType.U2)]
+        internal short Milliseconds;
+
+        internal DateTime ToDateTime() {
+            return new DateTime(Year, Month, Day, Hour, Minute, Second);
+        }
+    }
+
+
+}

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/MainPage.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/MainPage.xaml.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using IoTCoreDefaultApp.Utils;
 using System;
 using System.Globalization;
-using System.Threading.Tasks;
 using Windows.Networking.Connectivity;
 using Windows.Storage;
 using Windows.System;
@@ -59,7 +59,7 @@ namespace IoTCoreDefaultApp
 
                 timer = new DispatcherTimer();
                 timer.Tick += timer_Tick;
-                timer.Interval = TimeSpan.FromSeconds(30);
+                timer.Interval = TimeSpan.FromSeconds(10);
                 timer.Start();
             };
             this.Unloaded += (sender, e) =>
@@ -115,8 +115,12 @@ namespace IoTCoreDefaultApp
 
         private void UpdateDateTime()
         {
-            var t = DateTime.Now;
-            this.CurrentTime.Text = t.ToString("t", CultureInfo.CurrentCulture) + Environment.NewLine + t.ToString("d", CultureInfo.CurrentCulture);
+            // Using DateTime.Now is simpler, but the time zone is cached. So, we use a native method insead.
+            SYSTEMTIME localTime;
+            NativeTimeMethods.GetLocalTime(out localTime);
+
+            DateTime t = localTime.ToDateTime();
+            CurrentTime.Text = t.ToString("t", CultureInfo.CurrentCulture) + Environment.NewLine + t.ToString("d", CultureInfo.CurrentCulture);
         }
 
         private async void UpdateNetworkInfo()

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBEWelcome.xaml
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBEWelcome.xaml
@@ -33,14 +33,14 @@
   <ScrollViewer HorizontalScrollMode="Disabled" >
     <Grid Background="{StaticResource AccentBrush}">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="60"/>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="300"/>
-            <ColumnDefinition Width="30"/>
+            <ColumnDefinition Width="*" MaxWidth="40"/>
+            <ColumnDefinition Width="*" MinWidth="120"/>
+            <ColumnDefinition Width="*" MinWidth="120"/>
+            <ColumnDefinition Width="*" MaxWidth="40"/>
         </Grid.ColumnDefinitions>
             
         <Grid.RowDefinitions>
-            <RowDefinition Height="120"/>
+            <RowDefinition Height="*" MaxHeight="120"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -48,8 +48,8 @@
             <RowDefinition Height="20"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding [OOBEWelcomeTitleText]}" Style="{ThemeResource SubheaderTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Top"/>
-        <TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding [OOBEIntroText]}" Style="{ThemeResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,14,0,0"/>
+        <TextBlock Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="1" Text="{Binding [OOBEWelcomeTitleText]}" Style="{ThemeResource SubheaderTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+        <TextBlock Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="2" Text="{Binding [OOBEIntroText]}" Style="{ThemeResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,14,0,0"/>
 
         <TextBlock Grid.Column="1" Grid.Row="3" Text="{Binding [OOBELanguageSelectText]}" Style="{ThemeResource BaseTextBlockStyle}" HorizontalAlignment="Left" FontWeight="Normal" VerticalAlignment="Top" Margin="0,54,0,0"/>
         <ListView Grid.Column="1" Grid.Row="4" x:Name="LanguagesListView" ItemContainerStyle="{ThemeResource LanguageSelectionListViewItemStyle}" Margin="0,14,20,0" HorizontalAlignment="Left" Width="446" VerticalAlignment="Top" SelectionMode="Single" HorizontalContentAlignment="Stretch" SelectionChanged="LanguagesListBox_SelectionChanged" />

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBEWelcome.xaml
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBEWelcome.xaml
@@ -30,6 +30,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+  <ScrollViewer HorizontalScrollMode="Disabled" >
     <Grid Background="{StaticResource AccentBrush}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="60"/>
@@ -87,4 +88,5 @@
         </Grid>
 
     </Grid>
+  </ScrollViewer>
 </Page>


### PR DESCRIPTION
UpdateDateTime uses DateTime.Now, which uses a cached time zone. So,
when the time zone is changed, this is not reflected in the current date
time and a restart is required. To prevent that, we use a native method,
GetLocalTime() instead.
