### PR TITLE
Add a workaround in case NetworkInformation.GetHostNames() fails (it …

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Presenters/DeviceInfoPresenter.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Presenters/DeviceInfoPresenter.cs
@@ -13,13 +13,22 @@ namespace IoTCoreDefaultApp
     {
         public static string GetDeviceName()
         {
-            var hostname = NetworkInformation.GetHostNames()
-                .FirstOrDefault(x => x.Type == HostNameType.DomainName);
-            if (hostname != null)
+            try
             {
-                return hostname.CanonicalName;
+                var hostname = NetworkInformation.GetHostNames()
+                    .FirstOrDefault(x => x.Type == HostNameType.DomainName);
+                if (hostname != null)
+                {
+                    return hostname.CanonicalName;
+                }
             }
-            return "<no device name>";
+            catch (Exception)
+            {
+                // do nothing
+                // in some (strange) cases NetworkInformation.GetHostNames() fails... maybe a bug in the API...
+            }
+            var loader = new Windows.ApplicationModel.Resources.ResourceLoader();
+            return loader.GetString("NoDeviceName");
         }
 
         public static string GetBoardName()

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -701,4 +701,8 @@
     <value>Screensaver</value>
     <comment>Toggle switch for enabling the screensaver</comment>
   </data>
+  <data name="NoDeviceName" xml:space="preserve">
+    <value>&lt;no device name&gt;</value>
+    <comment>This is shown when we fail to retrieve a valid device name (very strange case)</comment>
+  </data>
 </root>


### PR DESCRIPTION
…does when the machine is set up with a weird name, e.g. '@#$^'
