### PR TITLE
Fixed issue #7811159 (or https://github.com/ms-iot/samples/issues/286).

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
@@ -107,7 +107,7 @@ namespace IoTCoreDefaultApp
                 {
                     if (deviceWatcher == null  ||  (DeviceWatcherStatus.Stopped == deviceWatcher.Status) )
                     {
-                        StartWatcher();
+                        StartWatchingAndDisplayConfirmationMessage();
                     }
                 }
             }
@@ -152,11 +152,6 @@ namespace IoTCoreDefaultApp
                     DisplayMessagePanel(confirmationMessage, MessageType.InformationalMessage);
                 });
             }
-        }
-
-        private void StartWatcherButton_Click(object sender, RoutedEventArgs e)
-        {
-            StartWatchingAndDisplayConfirmationMessage();
         }
 
         private void StartWatchingAndDisplayConfirmationMessage()


### PR DESCRIPTION
Calling StartWatchingAndDisplayConfirmationMessage() instead of StartWatcher() will clean the list to be repopulated when we navigate back to the page.

Also removed some dead code.
