### PR TITLE
Fix deadlock issue on Shutdown

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/MainPage.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/MainPage.xaml.cs
@@ -159,7 +159,10 @@ namespace IoTCoreDefaultApp
 
         private void ShutdownHelper(ShutdownKind kind)
         {
-            ShutdownManager.BeginShutdown(kind, TimeSpan.FromSeconds(0.5));
+            new System.Threading.Tasks.Task(() =>
+            {
+                ShutdownManager.BeginShutdown(kind, TimeSpan.FromSeconds(0));
+            }).Start();
         }
 
         private void ShutdownListView_ItemClick(object sender, ItemClickEventArgs e)


### PR DESCRIPTION
When shutting down the system from the Power Drop Down a Shutdown sequence is started with the OS.  The Shutdown request was blocking the UI thread which caused the PLM to Deadlock waiting for this app to respond to a "Suspend" request.  By moving the shutdown request to a background thread, the UI thread is released and the "Suspend" request from the PLM is properly satisfied.
