### PR TITLE
The RS1 Iot Onboarding Bg Task implements an AllJoyn Onboarding Produ…

### DIFF
--- a/IotOnboarding/IoTOnboardingService/OnboardingService.cs
+++ b/IotOnboarding/IoTOnboardingService/OnboardingService.cs
@@ -4,6 +4,7 @@ using org.alljoyn.Icon;
 using org.alljoyn.Onboarding;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Resources;
 using Windows.Devices.AllJoyn;
@@ -13,6 +14,7 @@ using Windows.Foundation;
 using Windows.Networking.Connectivity;
 using Windows.Security.Credentials;
 using Windows.Storage;
+using Windows.Storage.Search;
 using Windows.Storage.Streams;
 using Windows.ApplicationModel;
 using Windows.Data.Xml.Dom;
@@ -34,6 +36,7 @@ namespace IoTOnboardingService
             public string defaultDescription;
             public string defaultManufacturer;
             public string modelNumber;
+            public string presharedKey;
         }
         private AJOnboardingConfig _ajOnboardingConfig;
 
@@ -47,10 +50,12 @@ namespace IoTOnboardingService
         private const string NODE_DEFAULTDESCRIPTIONTEMPLATE = "IoTOnboarding/AllJoynOnboarding/DefaultDescription";
         private const string NODE_DEFAULTMANUFACTURER = "IoTOnboarding/AllJoynOnboarding/DefaultManufacturer";
         private const string NODE_MODELNUMBER = "IoTOnboarding/AllJoynOnboarding/ModelNumber";
+        private const string NODE_ALLJOYNPSK = "IoTOnboarding/AllJoynOnboarding/PresharedKey";
+
         private const string ATTRIBUTE_VALUE = "value";
 
         private const string SOFTAP_SSID_AJONBOARDING_PREFIX = "AJ_";
-         
+
         private static ushort _onboardingInterfaceVersion = 1412;
         private static ushort _iconInterfaceVersion = 1412;
         private static string _onboardingInstanceIdSettingName = "OnboardingInstanceId";
@@ -75,6 +80,8 @@ namespace IoTOnboardingService
         private object _stateLock;
 
         private StorageFile _iconFile;
+        private StorageFileQueryResult _query;
+        private bool _bIgnoreFirstChangeNotification;
 
         private async Task ResetConfig()
         {
@@ -94,9 +101,12 @@ namespace IoTOnboardingService
             configFile = await pkgFile.CopyAsync(localFolder);
         }
 
-        private async Task<bool> ReadConfig()
+        private async Task<Tuple<bool, AJOnboardingConfig, SoftAPConfig>> ReadConfig()
         {
             bool retVal = true;
+
+            AJOnboardingConfig ajOnboardCfg = new AJOnboardingConfig();
+            SoftAPConfig softAPCfg = new SoftAPConfig();
 
             try
             {
@@ -122,42 +132,107 @@ namespace IoTOnboardingService
                 var tempString = GetXmlNodeValue(xmlNode);
                 if (tempString == "true")
                 {
-                    _softAPConfig.enabled = true;
+                    softAPCfg.enabled = true;
                 }
                 else
                 {
-                    _softAPConfig.enabled = false;
+                    softAPCfg.enabled = false;
                 }
                 xmlNode = xmlConfig.SelectSingleNode(NODE_SOFTAPSSIDTEMPLATE);
-                _softAPConfig.ssid = GetXmlNodeValue(xmlNode);
+                softAPCfg.ssid = GetXmlNodeValue(xmlNode);
                 xmlNode = xmlConfig.SelectSingleNode(NODE_SOFTAPPASSWORD);
-                _softAPConfig.password = GetXmlNodeValue(xmlNode);
+                softAPCfg.password = GetXmlNodeValue(xmlNode);
 
                 // AllJoyn Onboarding config
                 xmlNode = xmlConfig.SelectSingleNode(NODE_ALLJOYNONBOARDINGENABLE);
+                tempString = GetXmlNodeValue(xmlNode);
                 if (tempString == "true")
                 {
-                    _ajOnboardingConfig.enabled = true;
+                    ajOnboardCfg.enabled = true;
                 }
                 else
                 {
-                    _ajOnboardingConfig.enabled = false;
+                    ajOnboardCfg.enabled = false;
                 }
                 xmlNode = xmlConfig.SelectSingleNode(NODE_DEFAULTDESCRIPTIONTEMPLATE);
-                _ajOnboardingConfig.defaultDescription = GetXmlNodeValue(xmlNode);
+                ajOnboardCfg.defaultDescription = GetXmlNodeValue(xmlNode);
                 xmlNode = xmlConfig.SelectSingleNode(NODE_DEFAULTMANUFACTURER);
-                _ajOnboardingConfig.defaultManufacturer = GetXmlNodeValue(xmlNode);
+                ajOnboardCfg.defaultManufacturer = GetXmlNodeValue(xmlNode);
                 xmlNode = xmlConfig.SelectSingleNode(NODE_MODELNUMBER);
-                _ajOnboardingConfig.modelNumber = GetXmlNodeValue(xmlNode);
+                ajOnboardCfg.modelNumber = GetXmlNodeValue(xmlNode);
+
+                // For backwards compatbility with original config file.  If the AllJoyn PSK is not found, 
+                // default to the ECDHE_NULL authentication method
+                xmlNode = xmlConfig.SelectSingleNode(NODE_ALLJOYNPSK);
+                if (xmlNode == null)
+                {
+                    ajOnboardCfg.presharedKey = "";
+                }
+                else
+                {
+                    ajOnboardCfg.presharedKey = GetXmlNodeValue(xmlNode);
+                }
+            }
+            catch (Exception)
+            {
+                retVal = false;
+            }
+
+            return new Tuple<bool, AJOnboardingConfig, SoftAPConfig>(retVal, ajOnboardCfg, softAPCfg);
+        }
+
+        private async Task<bool> MonitorConfigFile()
+        {
+            bool retVal = true;
+
+            try
+            {
+                // Watch for all ".xml" files (there is only the config.xml file in this app's data folder)
+                // And add a handler for when the folder contents change
+                var fileTypeQuery = new List<string>();
+                fileTypeQuery.Add(".xml");
+                var options = new Windows.Storage.Search.QueryOptions(Windows.Storage.Search.CommonFileQuery.DefaultQuery, fileTypeQuery);
+                _query = ApplicationData.Current.LocalFolder.CreateFileQueryWithOptions(options);
+                _query.ContentsChanged += FolderContentsChanged;
+
+                // Start Monitoring.  The first time this is called (after starting the query) we want to ignore the notification
+                _bIgnoreFirstChangeNotification = true;
+                var files = await _query.GetFilesAsync();
+
             }
             catch (Exception ex)
             {
                 retVal = false;
             }
 
-
-            return retVal; 
+            return retVal;
         }
+
+        private async void FolderContentsChanged(Windows.Storage.Search.IStorageQueryResultBase sender, object args)
+        {
+            // Ignore the first change notification that gets issued when MonitorConfigFile is called
+            if (_bIgnoreFirstChangeNotification)
+            {
+                _bIgnoreFirstChangeNotification = false;
+                return;
+            }
+
+            // Read the Config file on change
+            var configResult = await ReadConfig();
+            if (configResult.Item1 == true)
+            {
+
+                // If something changed in the config file then restart IotOnboarding 
+                if (!configResult.Item2.Equals(_ajOnboardingConfig) ||
+                    !configResult.Item3.Equals(_softAPConfig))
+                {
+                    sender.ContentsChanged -= FolderContentsChanged;
+                    Stop();
+                    Start();
+                }
+            }
+        }
+
         public OnboardingService()
         {
             _state = OnboardingState.NotConfigured;
@@ -196,17 +271,32 @@ namespace IoTOnboardingService
                 }
 
                 // read configuration
-                bool configOk = await ReadConfig();
-                if (!configOk)
+                var configResult = await ReadConfig();
+                if (!configResult.Item1)
                 {
                     // for some reason config file doesn't seem to be OK
                     // => reset config and try another time 
                     await ResetConfig();
-                    configOk = await ReadConfig();
-                    if(!configOk)
+                    configResult = await ReadConfig();
+                    if (!configResult.Item1)
                     {
                         throw new System.IO.InvalidDataException("Invalid configuration");
                     }
+                }
+                _ajOnboardingConfig = configResult.Item2;
+                _softAPConfig = configResult.Item3;
+
+                bool monitorOk = await MonitorConfigFile();
+                if (!monitorOk)
+                {
+                    throw new System.Exception("Unable to monitor configuration file for changes.  Unexpected.");
+                }
+
+
+                // If everything is disabled, then there's nothing to do.
+                if ((_softAPConfig.enabled == false) && (_ajOnboardingConfig.enabled == false))
+                {
+                    return;
                 }
 
                 // create softAP 
@@ -217,14 +307,14 @@ namespace IoTOnboardingService
                     string prefix = "";
                     string suffix = "";
                     string ssid = "";
-                    if(_ajOnboardingConfig.enabled)
+                    if (_ajOnboardingConfig.enabled)
                     {
                         prefix = SOFTAP_SSID_AJONBOARDING_PREFIX;
                         suffix = "_" + _onboardingInstanceId;
                     }
 
                     ssid = prefix + _softAPConfig.ssid + suffix;
-                    _softAccessPoint = new OnboardingAccessPoint(ssid, _softAPConfig.password);                    
+                    _softAccessPoint = new OnboardingAccessPoint(ssid, _softAPConfig.password);
                 }
 
                 // create AllJoyn related things
@@ -232,13 +322,25 @@ namespace IoTOnboardingService
                     _ajOnboardingConfig.enabled)
                 {
                     _busAttachment = new AllJoynBusAttachment();
-
-                    _busAttachment.AboutData.DefaultDescription = _ajOnboardingConfig.defaultDescription  + " instance Id " + _onboardingInstanceId;
+                    _busAttachment.AboutData.DefaultDescription = _ajOnboardingConfig.defaultDescription + " instance Id " + _onboardingInstanceId;
                     _busAttachment.AboutData.DefaultManufacturer = _ajOnboardingConfig.defaultManufacturer;
                     _busAttachment.AboutData.ModelNumber = _ajOnboardingConfig.modelNumber;
-
                     _onboardingProducer = new OnboardingProducer(_busAttachment);
                     _onboardingProducer.Service = this;
+                    _busAttachment.AuthenticationMechanisms.Clear();
+
+                    if (_ajOnboardingConfig.presharedKey.Length == 0)
+                    {
+                        _busAttachment.AuthenticationMechanisms.Add(AllJoynAuthenticationMechanism.EcdheNull);
+                    }
+                    else
+                    {
+                        _busAttachment.AuthenticationMechanisms.Add(AllJoynAuthenticationMechanism.EcdhePsk);
+                    }
+
+                    _busAttachment.CredentialsRequested += CredentialsRequested;
+                    _busAttachment.CredentialsVerificationRequested += CredentialsVerificationRequested;
+                    _busAttachment.AuthenticationComplete += AuthenticationComplete;
 
                     _iconProducer = new IconProducer(_busAttachment);
                     _iconProducer.Service = this;
@@ -263,35 +365,69 @@ namespace IoTOnboardingService
             }
         }
 
+        private void AuthenticationComplete(AllJoynBusAttachment sender, AllJoynAuthenticationCompleteEventArgs args)
+        {
+        }
+
+        private void CredentialsVerificationRequested(AllJoynBusAttachment sender, AllJoynCredentialsVerificationRequestedEventArgs args)
+        {
+        }
+
+        private void CredentialsRequested(AllJoynBusAttachment sender, AllJoynCredentialsRequestedEventArgs args)
+        {
+            var def = args.GetDeferral();
+
+            if (args.Credentials.AuthenticationMechanism == AllJoynAuthenticationMechanism.EcdhePsk)
+            {
+                args.Credentials.PasswordCredential.Password = _ajOnboardingConfig.presharedKey;
+            }
+
+            def.Complete();
+        }
+
         public void Stop()
         {
+            if (_query != null)
+            {
+                _query = null;
+            }
             if (_onboardingProducer != null)
             {
                 _onboardingProducer.Stop();
+                _onboardingProducer = null;
             }
             if (_iconProducer != null)
             {
                 _iconProducer.Stop();
+                _iconProducer = null;
+            }
+            if (_busAttachment != null)
+            {
+                _busAttachment = null;
             }
             if (_softAccessPoint != null)
             {
                 _softAccessPoint.Stop();
+                _softAccessPoint = null;
             }
             if (_deviceWatcher != null)
             {
                 _deviceWatcher.Stop();
+                _deviceWatcher = null;
             }
+            _wlanAdapterId = null;
+            _state = OnboardingState.NotConfigured;
         }
 
         private string GetXmlNodeValue(IXmlNode xmlNode)
         {
-            if(null == xmlNode)
+            if (null == xmlNode)
             {
                 throw new System.ArgumentNullException("GetXmlNodeValue wrong xmlNode");
             }
 
             var attribute = xmlNode.Attributes.GetNamedItem(ATTRIBUTE_VALUE);
-            if(attribute == null)
+            if (attribute == null)
             {
                 throw new System.IO.InvalidDataException("xml node " + xmlNode.LocalName + " has no attribute named " + ATTRIBUTE_VALUE);
             }
@@ -301,7 +437,7 @@ namespace IoTOnboardingService
 
         private void HandleAdapterAdded(DeviceWatcher sender, DeviceInformation information)
         {
-            if (_wlanAdapterId == null)
+            if (String.IsNullOrEmpty(_wlanAdapterId))
             {
                 _wlanAdapterId = information.Id;
 
@@ -312,24 +448,24 @@ namespace IoTOnboardingService
                         _softAccessPoint.Start();
                     }
                 }
-                _onboardingProducer.Start();
-                _iconProducer.Start();
+                _onboardingProducer?.Start();
+                _iconProducer?.Start();
             }
         }
 
         private void HandleAdapterRemoved(DeviceWatcher sender, DeviceInformationUpdate information)
         {
-            if (_wlanAdapterId != null && _wlanAdapterId == information.Id)
+            if (!String.IsNullOrEmpty(_wlanAdapterId) && _wlanAdapterId == information.Id)
             {
                 _softAccessPoint.Stop();
                 _wlanAdapterId = null;
 
-                _onboardingProducer.Stop();
-                _iconProducer.Stop();
+                _onboardingProducer?.Stop();
+                _iconProducer?.Stop();
             }
         }
 
-        private async void ConnectToNetwork(WiFiAdapter adapter, WiFiAvailableNetwork network)
+        private async Task<WiFiConnectionStatus> ConnectToNetwork(WiFiAdapter adapter, WiFiAvailableNetwork network)
         {
             lock (_stateLock)
             {
@@ -342,8 +478,9 @@ namespace IoTOnboardingService
                 connectionResult = await adapter.ConnectAsync(network, WiFiReconnectionKind.Automatic);
             }
             else
-            {
-                connectionResult = await adapter.ConnectAsync(network, WiFiReconnectionKind.Automatic, new PasswordCredential { Password = _personalApPassword });
+            {                
+                connectionResult = await adapter.ConnectAsync(network, WiFiReconnectionKind.Automatic, 
+                    new PasswordCredential { Password = _personalApPassword });
             }
 
             lock (_stateLock)
@@ -382,7 +519,10 @@ namespace IoTOnboardingService
                             }
                     }
                 }
+
             }
+            return connectionResult.ConnectionStatus;
+
         }
 
         public IAsyncOperation<OnboardingConfigureWifiResult> ConfigureWifiAsync(AllJoynMessageInfo info, string interfaceMemberSSID, string interfaceMemberPassphrase, short interfaceMemberAuthType)
@@ -423,11 +563,16 @@ namespace IoTOnboardingService
                 {
                     if (network.Ssid == _personalApSsid)
                     {
-                        _softAccessPoint?.Stop();
-                        this.ConnectToNetwork(adapter, network);
+                        var result = await this.ConnectToNetwork(adapter, network);
+                        if (result == WiFiConnectionStatus.Success)
+                        {
+                            _softAccessPoint?.Stop();
+                            return OnboardingConnectResult.CreateSuccessResult();
+                        }
+                        break;
                     }
                 }
-                return OnboardingConnectResult.CreateSuccessResult();
+                return OnboardingConnectResult.CreateFailureResult(1);
 
             }).AsAsyncOperation();
         }

--- a/IotOnboarding/IoTOnboardingTask/Config.xml
+++ b/IotOnboarding/IoTOnboardingTask/Config.xml
@@ -5,6 +5,7 @@
         <DefaultDescription value="IoTCore Onboarding service"/>
         <DefaultManufacturer value="Microsoft"/>
         <ModelNumber value="IoTCore Onboarding"/>
+        <Psk value=""/>
     </AllJoynOnboarding>
     <SoftAP>
         <Enabled value="true"/>

--- a/IotOnboarding/org.alljoyn.Onboarding/OnboardingConsumer.cpp
+++ b/IotOnboarding/org.alljoyn.Onboarding/OnboardingConsumer.cpp
@@ -128,7 +128,7 @@ IAsyncOperation<OnboardingConfigureWifiResult^>^ OnboardingConsumer::ConfigureWi
         QStatus status = alljoyn_proxybusobject_methodcall(
             ProxyBusObject,
             "org.alljoyn.Onboarding",
-            "ConfigureWifi",
+            "ConfigureWiFi",
             inputs,
             argCount,
             message,

--- a/IotOnboarding/org.alljoyn.Onboarding/OnboardingProducer.cpp
+++ b/IotOnboarding/org.alljoyn.Onboarding/OnboardingProducer.cpp
@@ -21,6 +21,7 @@
 //-----------------------------------------------------------------------------
 #include "pch.h"
 
+
 using namespace concurrency;
 using namespace Microsoft::WRL;
 using namespace Platform;
@@ -474,9 +475,14 @@ void OnboardingProducer::Start()
     }
     alljoyn_busobject_addinterface_announced(BusObject, interfaceDescription);
 
+
+    // NOTE: The Allseen Alliance onboarding spec (14.12 and earlier) list three possible names for the Wifi Onboarding Configuration method.
+    // (See https://allseenalliance.org/framework/documentation/learn/base-services/onboarding/interface).  There is currently an open
+    // issue with the Allseen Alliance https://jira.allseenalliance.org/browse/ASADOC-57, but we are conforming to the Windows 10 DAFIoT
+    // and Lifx Light-Bulb standard
     result = AddMethodHandler(
         interfaceDescription,
-        "ConfigureWifi",
+        "ConfigureWiFi",
         [](alljoyn_busobject busObject, const alljoyn_interfacedescription_member* member, alljoyn_message message) { UNREFERENCED_PARAMETER(member); CallConfigureWifiHandler(busObject, message); });
     if (result != ER_OK)
     {
@@ -591,10 +597,12 @@ int32 OnboardingProducer::RemoveMemberFromSession(_In_ String^ uniqueName)
 }
 
 PCSTR org::alljoyn::Onboarding::c_OnboardingIntrospectionXml = "<interface name=\"org.alljoyn.Onboarding\">"
+"  <description>A secure onboarding interface.  See https://allseenalliance.org/framework/documentation/learn/base-services/onboarding/interface </description>"
+"  <annotation name=\"org.alljoyn.Bus.Secure\" value=\"true\" />"
 "  <property name=\"Version\" type=\"q\" access=\"read\" />"
 "  <property name=\"State\" type=\"n\" access=\"read\" />"
 "  <property name=\"LastError\" type=\"(ns)\" access=\"read\" />"
-"  <method name=\"ConfigureWifi\">"
+"  <method name=\"ConfigureWiFi\">"
 "    <arg name=\"SSID\" type=\"s\" direction=\"in\" />"
 "    <arg name=\"passphrase\" type=\"s\" direction=\"in\" />"
 "    <arg name=\"authType\" type=\"n\" direction=\"in\" />"

--- a/IotOnboarding/org.alljoyn.Onboarding/org.alljoyn.Onboarding.xml
+++ b/IotOnboarding/org.alljoyn.Onboarding/org.alljoyn.Onboarding.xml
@@ -1,26 +1,42 @@
 <node xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="http://www.allseenalliance.org/schemas/introspect.xsd">
    <interface name="org.alljoyn.Onboarding">
-      <property name="Version" type="q" access="read"/>
+      <description>A secure onboarding interface</description>
+      <annotation name="org.alljoyn.Bus.Secure" value="true" />
+      <property name="Version" type="q" access="read">
+         <description>Interface version number</description>
+         <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+      </property>
       <property name="State" type="n" access="read"/>
+        <description>The configuration state</description>
+        <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+      </property>
       <property name="LastError" type="(ns)" access="read"/>
-      <method name="ConfigureWifi">
+        <description>The last error code and error message</description>
+        <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+      </property>
+      <method name="ConfigureWiFi">
+         <description>Sends the personal AP information to the onboardee</description>
          <arg name="SSID" type="s" direction="in"/>
          <arg name="passphrase" type="s" direction="in"/>
          <arg name="authType" type="n" direction="in"/>
          <arg name="status" type="n" direction="out"/>
       </method>
       <method name="Connect">
-<annotation name="org.freedesktop.DBus.Method.NoReply" value="true" />
+        <description>Tells the onboardee to connect to the personal AP</description>
+        <annotation name="org.freedesktop.DBus.Method.NoReply" value="true" />
       </method>
       <method name="Offboard">
+         <description>Tells the onboardee to disconnect from the personal AP</description>
          <annotation name="org.freedesktop.DBus.Method.NoReply" value="true" />
       </method>
       <method name="GetScanInfo">
+         <description>Scans all the Wi-Fi access points in the onboardee's proximity</description>
          <arg name="age" type="q" direction="out"/>
          <arg name="scanList" type="a(sn)" direction="out"/>
       </method>
       <signal name="ConnectionResult">
+         <description>This signal is emitted when the connection attempt against the personal AP is completed</description>
          <arg type="(ns)" />
       </signal>
    </interface>


### PR DESCRIPTION
…cer as one mechanism for onboarding a device.  Unfortunately the RS1 implementation uses a "non-secure" AllJoyn Interface definition, but should have used the "Secure" mechanism.  Additionally there are several minor bugs that have been found that are included in this change.

```
 This change:
 1a) Changes the AllJoyn Onboarding Producer to implement a Secure interface.
 1b) Provides a mechanism for configuring the AllJoyn Onboarding Authentication Mechanism (ECDHE_PSK or ECDHE_NULL)
 2) Changed the Onboarding "ConfigureWifi" interface to conform with the method name used by the DAFIot Provider (Is now set to  ConfigureWiFi- capital F)
 3) Fixes an issue where both the SoftAP and AllJoyn Onboarding features are disabled.
 4) Fixes an issue where the AllJoyn Onboarding enable/disable control was ignored (previously it always followed the SoftAP setting)
 5) Supports a File Watcher so that configuration changes made via the WeBB do not require the IOT Device to reboot.
 6) Is backwars compatible with RS1's WebB.  The default is ECDHE_NULL authentication if the PSK config node is missing in the XML file.
```
