### PR TITLE
MSFT: 8554547  This change adds passphrase conversion support on the …

### DIFF
--- a/IotOnboarding/IoTOnboardingTask/Package.appxmanifest
+++ b/IotOnboarding/IoTOnboardingTask/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:iot="http://schemas.microsoft.com/appx/manifest/iot/windows10" IgnorableNamespaces="uap mp iot">
-  <Identity Name="IoTOnboardingTask-uwp" Publisher="CN=MSFT" Version="1.0.0.0" />
+  <Identity Name="IoTOnboardingTask-uwp" Publisher="CN=MSFT" Version="1.0.1.0" />
   <mp:PhoneIdentity PhoneProductId="cc131251-a2f0-42bf-abe8-1a901885dcbb" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>IoTOnboardingTask</DisplayName>


### PR DESCRIPTION
…IotOnboarding producer.

The AllJoyn Onboarding protocol expects that the passphrase or network key is converted to a
HEXized Ascii String (e.g. “Apple123” converts to "4170706C65313233").  On the AllJoyn Producer
side however, the HEXized string must be converted back to a passphrase to make the WinRT call
with the correct passphrase.  This code converts the string back before onboarding the device
to the desired network.
