### PR TITLE
Bugfix at HidInjector sample for sending touch messages to driver.

### DIFF
--- a/HIDInjector/app/HidInjectorTest.c
+++ b/HIDInjector/app/HidInjectorTest.c
@@ -155,12 +155,9 @@ BOOL SendTouch(HANDLE File,
         TouchState.Report.TouchReport.ContactIndentifier = contacts[i].pointerInfo.pointerId;
 
         //the value is expected to be normalized and clamped to[0, 32767]
-		USHORT physicalMaxX = 0x7FFF;	//Physical maximum given for the X usage at the touch part of the HID_REPORT_DESCRIPTOR at the driver (HidInjectorKd.c).
-		USHORT physicalMaxY = 0x7FFF;	//Physical maximum given for the Y usage at the touch part of the HID_REPORT_DESCRIPTOR at the driver (HidInjectorKd.c).
-
 		//normalize factor -> physical resolution to screen resolution
-		float normX = (float)physicalMaxX / GetSystemMetrics(SM_CXSCREEN);
-		float normY = (float)physicalMaxY / GetSystemMetrics(SM_CYSCREEN);
+		float normX = (float)TOUCH_PHYSICAL_MAX / GetSystemMetrics(SM_CXSCREEN);
+		float normY = (float)TOUCH_PHYSICAL_MAX / GetSystemMetrics(SM_CYSCREEN);
 
 		//normalize and clamp
         TouchState.Report.TouchReport.AbsoluteX = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.x * normX, 0x7FFF));

--- a/HIDInjector/app/HidInjectorTest.c
+++ b/HIDInjector/app/HidInjectorTest.c
@@ -154,9 +154,17 @@ BOOL SendTouch(HANDLE File,
         TouchState.Report.TouchReport.ContactCount = i == 0 ? count : 0; // Only the first report contains the contact count for the frame.
         TouchState.Report.TouchReport.ContactIndentifier = contacts[i].pointerInfo.pointerId;
 
-        //the value is expected to be normalized and clamped to[0, 65535]
-        TouchState.Report.TouchReport.AbsoluteX = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.x * GetSystemMetrics(SM_CXSCREEN), 0x7FFF));
-        TouchState.Report.TouchReport.AbsoluteY = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.y * GetSystemMetrics(SM_CYSCREEN), 0x7FFF));
+        //the value is expected to be normalized and clamped to[0, 32767]
+		USHORT physicalMaxX = 0x7FFF;	//Physical maximum given for the X usage at the touch part of the HID_REPORT_DESCRIPTOR at the driver (HidInjectorKd.c).
+		USHORT physicalMaxY = 0x7FFF;	//Physical maximum given for the Y usage at the touch part of the HID_REPORT_DESCRIPTOR at the driver (HidInjectorKd.c).
+
+		//normalize factor -> physical resolution to screen resolution
+		float normX = (float)physicalMaxX / GetSystemMetrics(SM_CXSCREEN);
+		float normY = (float)physicalMaxY / GetSystemMetrics(SM_CYSCREEN);
+
+		//normalize and clamp
+        TouchState.Report.TouchReport.AbsoluteX = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.x * normX, 0x7FFF));
+        TouchState.Report.TouchReport.AbsoluteY = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.y * normY, 0x7FFF));
 
         if (contacts[i].pointerInfo.pointerFlags & POINTER_FLAG_INCONTACT)
         {

--- a/HIDInjector/app/HidInjectorTest.c
+++ b/HIDInjector/app/HidInjectorTest.c
@@ -154,14 +154,14 @@ BOOL SendTouch(HANDLE File,
         TouchState.Report.TouchReport.ContactCount = i == 0 ? count : 0; // Only the first report contains the contact count for the frame.
         TouchState.Report.TouchReport.ContactIndentifier = contacts[i].pointerInfo.pointerId;
 
-        //the value is expected to be normalized and clamped to[0, 32767]
+        //the value is expected to be normalized and clamped to[0, TOUCH_PHYSICAL_MAX]
 		//normalize factor -> physical resolution to screen resolution
 		float normX = (float)TOUCH_PHYSICAL_MAX / GetSystemMetrics(SM_CXSCREEN);
 		float normY = (float)TOUCH_PHYSICAL_MAX / GetSystemMetrics(SM_CYSCREEN);
 
 		//normalize and clamp
-        TouchState.Report.TouchReport.AbsoluteX = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.x * normX, 0x7FFF));
-        TouchState.Report.TouchReport.AbsoluteY = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.y * normY, 0x7FFF));
+        TouchState.Report.TouchReport.AbsoluteX = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.x * normX, TOUCH_PHYSICAL_MAX));
+        TouchState.Report.TouchReport.AbsoluteY = (USHORT)max(0, min(contacts[i].pointerInfo.ptPixelLocation.y * normY, TOUCH_PHYSICAL_MAX));
 
         if (contacts[i].pointerInfo.pointerFlags & POINTER_FLAG_INCONTACT)
         {

--- a/HIDInjector/driver/HidInjectorKd.c
+++ b/HIDInjector/driver/HidInjectorKd.c
@@ -110,7 +110,7 @@ HID_REPORT_DESCRIPTOR       G_DefaultReportDescriptor[] =
     0x16, 0x00, 0x00,               //     Logical Minimum(0)
     0x26, 0xFF, 0x7F,               //     Logical Maximum(32767)
     0x36, 0x00, 0x00,               //     Physical Minimum(0)
-    0x46, 0xFF, 0x7F,               //     Physical Maximum(32767)
+    0x46, TOUCH_PHYSICAL_MAX & 0xFF, (TOUCH_PHYSICAL_MAX >> 8) & 0xFF, //     Physical Maximum(32767)
     0x66, 0x00, 0x00,               //     Unit(None)
     0x75, 0x10,                     //     REPORT_SIZE(16)
     0x95, 0x02,                     //     REPORT_COUNT(2)

--- a/HIDInjector/inc/common.h
+++ b/HIDInjector/inc/common.h
@@ -77,6 +77,7 @@ typedef struct _HIDINJECTOR_INPUT_REPORT {
 #define TOUCH_TIP_SWITCH		0x01
 #define TOUCH_IN_RANGE			0x02
 #define TOUCH_MAX_FINGER		0x0a // 10
+#define TOUCH_PHYSICAL_MAX		0x7FFF	//Physical maximum given for the X and Y usage at the touch part of the HID_REPORT_DESCRIPTOR at the driver.
 
 #include <poppack.h>
 


### PR DESCRIPTION
The original code didn't consider the physical maximum given in the drivers HID report descriptor for the touch device. This produces wrong touch positions. The bugfix uses these values from the HID report descriptor.