### PR TITLE
Bugfix for generating signal parameters

### DIFF
--- a/AllJoyn/Platform/BridgeRT/DeviceSignal.cpp
+++ b/AllJoyn/Platform/BridgeRT/DeviceSignal.cpp
@@ -231,7 +231,7 @@ QStatus DeviceSignal::BuildSignature()
         // add parameter name to parameter list
         if (0 != m_parameterNames.length())
         {
-            m_parameterNames == ",";
+            m_parameterNames += ",";
         }
         m_parameterNames += ConvertTo<std::string>(signalParam->Name->Data());
         m_parameterNames += hint;


### PR DESCRIPTION
The separation of parameter names didn't work. The code in line 234 mistakenly performed a boolean check instead of appending the comma.