### PR TITLE
Add Voice Activation, Cortana Consent and Cortana AboutMe button to IotCoreDefaultApp.

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>IoTCoreDefaultApp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10545.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.14993.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14993.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -111,11 +111,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsIoT, Version=10.0.10586.0">
-      <Name>Windows IoT Extension SDK</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
@@ -124,6 +119,7 @@
     <Compile Include="Presenters\DeviceInfoPresenter.cs" />
     <Compile Include="Presenters\LanguageManager.cs" />
     <Compile Include="Presenters\NetworkPresenter.cs" />
+    <Compile Include="Utils\CortanaHelper.cs" />
     <Compile Include="Utils\DeviceTypeInformation.cs" />
     <Compile Include="Utils\Constants.cs" />
     <Compile Include="Utils\NativeTimeMethods.cs" />
@@ -256,6 +252,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="WindowsIoT, Version=10.0.14993.0">
+      <Name>Windows IoT Extensions for the UWP</Name>
+    </SDKReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/IoTCoreDefaultApp.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>IoTCoreDefaultApp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.14993.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14993.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -106,6 +106,11 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
     <CompilerResponseFile>$(MSBuildProjectDirectory)\CscOptions.rsp</CompilerResponseFile>
   </PropertyGroup>
+  <ItemGroup>
+    <SDKReference Include="WindowsIoT, Version=10.0.10586.0">
+      <Name>Windows IoT Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
     <None Include="project.json" />
@@ -253,11 +258,6 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-  <ItemGroup>
-    <SDKReference Include="WindowsIoT, Version=10.0.14993.0">
-      <Name>Windows IoT Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
@@ -276,4 +276,21 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="CortanaSDKCompatPatch" BeforeTargets="ResolveSDKReference" AfterTargets="GetInstalledSDKLocations">
+    <PropertyGroup>
+      <IoTCortanaApiMinVersion>10.0.14993.0</IoTCortanaApiMinVersion>
+      <IoTCortanaApiPresent Condition="Exists('$(TargetPlatformSdkPath)\bin\$(IoTCortanaApiMinVersion)\')">true</IoTCortanaApiPresent>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(IoTCortanaApiPresent)' == 'true'">
+      <TargetPlatformVersion>$(IoTCortanaApiMinVersion)</TargetPlatformVersion>
+      <TargetPlatformMinVersion>$(IoTCortanaApiMinVersion)</TargetPlatformMinVersion>
+      <DefineConstants>$(DefineConstants);BUILDWITHCORTANA</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup Condition="'$(IoTCortanaApiPresent)' == 'true'">
+      <SDKReference Remove="WindowsIoT, Version=10.0.10586.0"/>
+      <SDKReference Include="WindowsIoT, Version=$(IoTCortanaApiMinVersion)">
+        <Name>Windows IoT Extensions for the UWP</Name>
+      </SDKReference>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Package.appxmanifest
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Package.appxmanifest
@@ -13,7 +13,7 @@
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14993.0" MaxVersionTested="10.0.14993.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Package.appxmanifest
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Package.appxmanifest
@@ -5,7 +5,7 @@
    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
    xmlns:iot="http://schemas.microsoft.com/appx/manifest/iot/windows10"
    IgnorableNamespaces="uap mp iot">
-  <Identity Name="IoTCoreDefaultApp" Publisher="CN=MSFT" Version="1.1.0.0" />
+  <Identity Name="IoTCoreDefaultApp" Publisher="CN=MSFT" Version="1.2.0.0" />
   <mp:PhoneIdentity PhoneProductId="6803bb24-895c-48b4-915c-13e4ea5d023e" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>IoTCoreDefaultApp</DisplayName>
@@ -13,7 +13,7 @@
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14993.0" MaxVersionTested="10.0.14993.0" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -769,10 +769,20 @@ Alternatively, click the button below to enter the administrator's username/pass
   <data name="VirtualNetworkAdapter" xml:space="preserve">
     <value>Virtual Network Adapter</value>
   </data>
-  <data name="CortanaSettingsText" xml:space="preserve">
-    <value>Cortana &amp; Search settings</value>
+  <data name="CortanaAboutMeText" xml:space="preserve">
+    <value>About Me</value>
+    <comment>Button launches Cortana's "About Me" page to manage certain Cortana Settings</comment>
   </data>
   <data name="CortanaTitleText" xml:space="preserve">
+    <value>Manage Cortana Settings</value>
+    <comment>Title of Cortana Settings Management Page</comment>
+  </data>
+  <data name="CortanaPreferencesText" xml:space="preserve">
     <value>Cortana</value>
+    <comment>Cortana Preferences on left side of settings screen</comment>
+  </data>
+  <data name="CortanaVoiceActivationText" xml:space="preserve">
+    <value>Let Cortana respond to "Hey Cortana"</value>
+    <comment>Toggle switch for enabling voice activation.</comment>
   </data>
 </root>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/CortanaHelper.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/CortanaHelper.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Services.Cortana;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace IoTCoreDefaultApp
+{
+    class CortanaHelper
+    {
+        public static void LaunchCortanaToConsentPageAsyncIfNeeded()
+        {
+            // Do nothing for devices that do not support Cortana
+            if (CortanaSettings.IsSupported())
+            {
+                // Ordinarily, this is run during a first use Out-of-box-Experience (OOBE) and voice consent will NOT be granted.
+                // So, we launch Cortana to it's Consent Page as part of OOBE to give the end-user an opportunity to give consent.
+                // However on development systems where the IotCoreDefaultApp may be deployed repeatedly after Cortana consent has
+                // already been granted we will bypass the Cortana Launch.
+                var cortanaSettings = CortanaSettings.GetDefault();
+                if (!cortanaSettings.HasUserConsentToVoiceActivation)
+                {
+                    LaunchCortanaToConsentPageAsync();
+                }
+            }
+        }
+
+        public static Task<bool> LaunchCortanaToConsentPageAsync()
+        {
+            // NOTE: When integrating this sample code into your specific device, Microsoft recommends changing the QuerySourceSecondaryId in the URI to "IoT_<MANUFACTURER>_<DEVICE_DESCRIPTION>"
+            var uri = new Uri("ms-cortana://CapabilitiesPrompt/?RequestedCapabilities=InputPersonalization,Microphone,Personalization&QuerySourceSecondaryId=IoT&QuerySource=Microphone&DismissAfterConsent=True");
+            return Windows.System.Launcher.LaunchUriAsync(uri).AsTask<bool>();
+        }
+
+        public static Task<bool> LaunchCortanaToAboutMeAsync()
+        {
+            var uri = new Uri("ms-cortana://AboutMe");
+            return Windows.System.Launcher.LaunchUriAsync(uri).AsTask<bool>();
+        }
+    }
+}

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/CortanaHelper.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Utils/CortanaHelper.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
+#if BUILDWITHCORTANA
 using Windows.Services.Cortana;
+#endif
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 
@@ -13,6 +15,7 @@ namespace IoTCoreDefaultApp
     {
         public static void LaunchCortanaToConsentPageAsyncIfNeeded()
         {
+#if BUILDWITHCORTANA
             // Do nothing for devices that do not support Cortana
             if (CortanaSettings.IsSupported())
             {
@@ -26,6 +29,7 @@ namespace IoTCoreDefaultApp
                     LaunchCortanaToConsentPageAsync();
                 }
             }
+#endif
         }
 
         public static Task<bool> LaunchCortanaToConsentPageAsync()

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBENetwork.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBENetwork.xaml.cs
@@ -5,7 +5,6 @@ using System;
 using Windows.Devices.WiFi;
 using Windows.Networking.Connectivity;
 using Windows.Security.Credentials;
-using Windows.Services.Cortana;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBENetwork.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBENetwork.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using Windows.Devices.WiFi;
 using Windows.Networking.Connectivity;
 using Windows.Security.Credentials;
+using Windows.Services.Cortana;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -138,6 +139,7 @@ namespace IoTCoreDefaultApp
             {
                 await dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
+                    CortanaHelper.LaunchCortanaToConsentPageAsyncIfNeeded();
                     NavigationUtils.NavigateToScreen(typeof(MainPage));
                 });
             }
@@ -200,6 +202,7 @@ namespace IoTCoreDefaultApp
 
         private void SkipButton_Clicked(object sender, RoutedEventArgs e)
         {
+            CortanaHelper.LaunchCortanaToConsentPageAsyncIfNeeded();
             NavigationUtils.NavigateToScreen(typeof(MainPage));
         }
 

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBEWelcome.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBEWelcome.xaml.cs
@@ -119,6 +119,11 @@ namespace IoTCoreDefaultApp
 
             await Window.Current.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
+                // If the next screen is the main-page, navigate there, but also launch Cortana to its Consent Page independently
+                if (nextScreen == typeof(MainPage))
+                {
+                    CortanaHelper.LaunchCortanaToConsentPageAsyncIfNeeded();
+                }
                 NavigationUtils.NavigateToScreen(nextScreen);
             });
         }

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml
@@ -229,6 +229,9 @@
             <ListViewItem HorizontalAlignment="Stretch" Height="48">
                 <TextBlock x:Name="BluetoothListViewItem" Text="{Binding [BluetoothPreferencesText]}" />
             </ListViewItem>
+            <ListViewItem HorizontalAlignment="Stretch" Height="48">
+                <TextBlock x:Name="CortanaListViewItem" Text="{Binding [CortanaPreferencesText]}" />
+            </ListViewItem>
         </ListView>
 
         <ScrollViewer x:Name="BasicPreferencesGridView" Grid.Column="2" Grid.Row="1">
@@ -248,8 +251,6 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="30"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>                    
                     <RowDefinition Height="408"/>
                     <RowDefinition Height="30"/>
@@ -263,8 +264,6 @@
                 <ComboBox Grid.Column="1" Grid.Row="4" HorizontalAlignment="Left" x:Name="LanguageComboBox" FontSize="16" Margin="0,10,0,0" Width="446" SelectionChanged="LanguageComboBox_SelectionChanged" />
                 <TextBlock Grid.Column="1" Grid.Row="6" Text="{Binding [KeyboardTitleText]}" Style="{StaticResource SubtitleTextBlockStyle}" FontWeight="Normal" />
                 <ComboBox Grid.Column="1" Grid.Row="7" HorizontalAlignment="Left" x:Name="InputLanguageComboBox" FontSize="16" Margin="0,10,0,0" Width="446" SelectionChanged="InputLanguageComboBox_SelectionChanged"/>
-                <TextBlock Grid.Column="1" Grid.Row="9" Text="{Binding [CortanaTitleText]}" Style="{StaticResource SubtitleTextBlockStyle}" FontWeight="Normal"/>
-                <Button Grid.Column="1" Grid.Row="10" x:Name="LaunchCortanaButton" Content="{Binding [CortanaSettingsText]}"  Margin="0,10,0,0" HorizontalAlignment="Left" Click="LaunchCortanaButton_Click" />
             </Grid>
         </ScrollViewer>
 
@@ -330,6 +329,18 @@
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer  x:Name="CortanaGrid" Grid.Column="2" Grid.Row="1" Visibility="Collapsed">
+            <StackPanel Margin="24,25,0,0" Orientation="Vertical">
+                <TextBlock x:Uid="CortanaManagement" Text="{Binding [CortanaTitleText]}"  Style="{StaticResource SubtitleTextBlockStyle}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                <ToggleSwitch Margin="0,10,0,0" Style="{StaticResource IoTCoreDefaultAppToggleStyle}" Toggled="CortanaVoiceActivationSwitch_Toggled"  x:Name="CortanaVoiceActivationSwitch" Visibility="Visible">
+                    <ToggleSwitch.Header>
+                        <TextBlock Text="{Binding [CortanaVoiceActivationText]}" Style="{StaticResource SubtitleTextBlockStyle}" FontWeight="Normal" />
+                    </ToggleSwitch.Header>
+                </ToggleSwitch>
+                <Button x:Name="CortanaAboutMeButton" Margin="0,20,0,0" Content="{Binding [CortanaAboutMeText]}" Click="CortanaAboutMeButton_Click" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
@@ -8,7 +8,9 @@ using Windows.Devices.Enumeration;
 using Windows.Devices.WiFi;
 using Windows.Foundation;
 using Windows.Security.Credentials;
+#if BUILDWITHCORTANA
 using Windows.Services.Cortana;
+#endif
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -102,6 +104,7 @@ namespace IoTCoreDefaultApp
 
         private void SetupCortana()
         {
+#if BUILDWITHCORTANA
             var isCortanaSupported = CortanaSettings.IsSupported();
             cortanaConsentRequestedFromSwitch = false;
 
@@ -123,6 +126,7 @@ namespace IoTCoreDefaultApp
                     CortanaVoiceActivationSwitch.IsOn = cortanaSettings.IsVoiceActivationEnabled;
                 }
             }
+#endif
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -1054,6 +1058,7 @@ namespace IoTCoreDefaultApp
 
         private void CortanaVoiceActivationSwitch_Toggled(object sender, RoutedEventArgs e)
         {
+#if BUILDWITHCORTANA
             var cortanaSettings = CortanaSettings.GetDefault();
             var cortanaVoiceActivationSwitch = (ToggleSwitch) sender;
 
@@ -1087,10 +1092,12 @@ namespace IoTCoreDefaultApp
                     CortanaVoiceActivationSwitch.IsEnabled = true;
                 });                
             }
+#endif
         }
 
         private void Window_Activated(object sender, WindowActivatedEventArgs e)
         {
+#if BUILDWITHCORTANA
             switch (e.WindowActivationState)
             {
                 case CoreWindowActivationState.PointerActivated:
@@ -1126,6 +1133,7 @@ namespace IoTCoreDefaultApp
                 default:
                     break;
             }
+#endif
         }
 
         private void CortanaAboutMeButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This change encapsulates UI changes to the IoTCoreDefaultApp for providing

This change encapsulates UI changes to the IoTCoreDefaultApp for providingConsent and Voice Activation to Cortana.  The change:
  - integrates with the latest API's available in the latest standalone SDK.
  - removes a temporary button from the BASIC settings page
  - adds a dedicated Cortana settings page to to the IotCoreDefaultApp
  - adds a "Voice Activation" toggle switch that will launch Cortana to the Consent page if Consent has not been granted
  - provides a mechansim for launching the AboutMe settings page within Cortana
  - launches Cortana as part of the OOBE experience

Lines starting