### PR TITLE
Show error message when WiFi scanning is aborted

### DIFF
--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Presenters/NetworkPresenter.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Presenters/NetworkPresenter.cs
@@ -192,15 +192,7 @@ namespace IoTCoreDefaultApp
                     return false;
                 }
 
-                try
-                {
-                    await adapter.ScanAsync();
-                }
-                catch (Exception e)
-                {
-                    Debug.WriteLine(String.Format("Error scanning {0}: 0x{1:X}: {2}", adapter.NetworkAdapter.NetworkAdapterId, e.HResult, e.Message));
-                    continue;
-                }
+                await adapter.ScanAsync();
 
                 if (adapter.NetworkReport == null)
                 {

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Presenters/NetworkPresenter.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Presenters/NetworkPresenter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -191,7 +192,15 @@ namespace IoTCoreDefaultApp
                     return false;
                 }
 
-                await adapter.ScanAsync();
+                try
+                {
+                    await adapter.ScanAsync();
+                }
+                catch (Exception e)
+                {
+                    Debug.WriteLine(String.Format("Error scanning {0}: 0x{1:X}: {2}", adapter.NetworkAdapter.NetworkAdapterId, e.HResult, e.Message));
+                    continue;
+                }
 
                 if (adapter.NetworkReport == null)
                 {

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/de-DE/Resources.resw
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Strings/de-DE/Resources.resw
@@ -201,7 +201,7 @@
     <comment>Board name</comment>
   </data>
   <data name="SkipStepText" xml:space="preserve">
-    <value>Diesen Schritt überspringen,</value>
+    <value>Diesen Schritt überspringen</value>
   </data>
   <data name="WifiText" xml:space="preserve">
     <value>WLAN</value>

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBENetwork.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/OOBENetwork.xaml.cs
@@ -2,6 +2,8 @@
 
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using Windows.Devices.WiFi;
 using Windows.Networking.Connectivity;
 using Windows.Security.Credentials;
@@ -76,7 +78,18 @@ namespace IoTCoreDefaultApp
         {
             if (await networkPresenter.WifiIsAvailable())
             {
-                var networks = await networkPresenter.GetAvailableNetworks();
+                IList<WiFiAvailableNetwork> networks;
+                try
+                {
+                    networks = await networkPresenter.GetAvailableNetworks();
+                }
+                catch (Exception e)
+                {
+                    Debug.WriteLine(String.Format("Error scanning: 0x{0:X}: {1}", e.HResult, e.Message));
+                    NoWifiFoundText.Text = e.Message;
+                    NoWifiFoundText.Visibility = Visibility.Visible;
+                    return;
+                }
 
                 if (networks.Count > 0)
                 {

--- a/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
+++ b/IoTCoreDefaultApp/IoTCoreDefaultApp/Views/Settings.xaml.cs
@@ -2,7 +2,9 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using Windows.Devices.Bluetooth.Rfcomm;
 using Windows.Devices.Enumeration;
 using Windows.Devices.WiFi;
@@ -267,9 +269,20 @@ namespace IoTCoreDefaultApp
         private async void SetupWifi()
         {
             if (await networkPresenter.WifiIsAvailable())
-            {    
-                var networks = await networkPresenter.GetAvailableNetworks();
-             
+            {
+                IList<WiFiAvailableNetwork> networks;
+                try
+                {
+                    networks = await networkPresenter.GetAvailableNetworks();
+                }
+                catch (Exception e)
+                {
+                    Debug.WriteLine(String.Format("Error scanning: 0x{0:X}: {1}", e.HResult, e.Message));
+                    NoWifiFoundText.Text = e.Message;
+                    NoWifiFoundText.Visibility = Visibility.Visible;
+                    return;
+                }
+
                 if (networks.Count > 0)
                 {
 

--- a/WiFiConnector/CS/WiFiConnect_Scenario.xaml.cs
+++ b/WiFiConnector/CS/WiFiConnect_Scenario.xaml.cs
@@ -70,7 +70,15 @@ namespace WiFiConnect
 
         private async void Button_Click(object sender, RoutedEventArgs e)
         {
-            await firstAdapter.ScanAsync();
+            try
+            {
+                await firstAdapter.ScanAsync();
+            }
+            catch (Exception err)
+            {
+                rootPage.NotifyUser(String.Format("Error scanning WiFi adapter: 0x{0:X}: {1}", err.HResult, err.Message), NotifyType.ErrorMessage);
+                return;
+            }
             ConnectionBar.Visibility = Visibility.Collapsed;
             DisplayNetworkReport(firstAdapter.NetworkReport);
         }


### PR DESCRIPTION
Filter E_ABORT exceptions that might happen during `ScanAsync()`. Now IoTCoreDefaultApp the error instead of crashing and WiFiConnector shows the error in the notification bar.